### PR TITLE
Fix Ward Format in Patient Display card

### DIFF
--- a/src/main/java/seedu/noknock/model/person/Ward.java
+++ b/src/main/java/seedu/noknock/model/person/Ward.java
@@ -19,7 +19,7 @@ public class Ward {
      * @param room
      */
     public Ward(String room) {
-        this.room = room;
+        this.room = room.toUpperCase();
     }
 
     public static boolean isValidWard(String ward) {


### PR DESCRIPTION
Fixes #146
Fixed Display formatting for Wards such that alphabets in valid inputs are automatically made to be Upper-case